### PR TITLE
Fix buggy catch block

### DIFF
--- a/lib/openapi2schema.js
+++ b/lib/openapi2schema.js
@@ -117,7 +117,9 @@ function buildPaths(paths, options, schemaOptions) {
 			} catch (e) {
 				if (e.name == 'InvalidTypeError') {
 					throw new Error(e.message + ' in ' + pathName);
-				}
+                } else {
+                    throw e;
+                }
 			}
 
 			if (options.clean && isEmptyObj(resultMethod)) {

--- a/lib/openapi2schema.js
+++ b/lib/openapi2schema.js
@@ -117,9 +117,9 @@ function buildPaths(paths, options, schemaOptions) {
 			} catch (e) {
 				if (e.name == 'InvalidTypeError') {
 					throw new Error(e.message + ' in ' + pathName);
-                } else {
-                    throw e;
-                }
+				} else {
+					throw e;
+				}
 			}
 
 			if (options.clean && isEmptyObj(resultMethod)) {


### PR DESCRIPTION
We noticed that running this script it would swallow some exceptions. We
think it's related to this catch block: it processes one type of error,
but not others.

# Test plan:
## Verify problem
1. git patch the following in the CODEZ repo (has a problem with the overrides):
```
diff --git a/asana2/asana/server/openapi_spec/src/components/schemas.yaml b/asana2/asana/server/openapi_spec/src/components/schemas.yaml
index 0a39f0cde865..5b7435737a9e 100644
--- a/asana2/asana/server/openapi_spec/src/components/schemas.yaml
+++ b/asana2/asana/server/openapi_spec/src/components/schemas.yaml
@@ -2097,6 +2097,12 @@ schemas:
               HTML formatted text for the project brief.
             type: string
             example: "<body>This is a <strong>project brief</strong>.</body>"
+          text:
+            description: >-
+              [Opt In](/docs/input-output-options).
+              The plain text of the project brief.
+            type: string
+            example: "This is a project brief."
   ProjectBriefCompact:
     x-private: true
     allOf:
@@ -2111,27 +2117,17 @@ schemas:
     x-private: true
     allOf:
       - $ref: '#/components/schemas/ProjectBriefBase'
-      - type: object
-        properties:
-          text:
-            description: >-
-              The plain text of the project brief. When writing to a project
-              brief, you can specify either `html_text` (preferred) or `text`,
-              but not both.
-            type: string
-            example: "This is a project brief."
+      - x-docs-overrides:
+          properties.text.description: >-
+            The plain text of the project brief. When writing to a project
+            brief, you can specify either `html_text` (preferred) or `text`,
+            but not both.
   ProjectBriefResponse:
     x-private: true
     allOf:
       - $ref: '#/components/schemas/ProjectBriefBase'
       - type: object
         properties:
-          text:
-            description: >-
-              [Opt In](/docs/input-output-options).
-              The plain text of the project brief.
-            type: string
-            example: "This is a project brief."
           permalink_url:
             type: string
             readOnly: true
```
2. Run our builder script and blackbox tests: `./gen_sand_env.sh; npm test`
3. Notice they fail for Project Briefs
 
## Verify Fix
1. git patch the following (the same from the above, with the new package with the fix)
```
diff --git a/asana2/asana/server/api/postman/package-lock.json b/asana2/asana/server/api/postman/package-lock.json
index 7811131adaf4..01d1bce3a289 100644
--- a/asana2/asana/server/api/postman/package-lock.json
+++ b/asana2/asana/server/api/postman/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^2.18.0",
         "json-schema-ref-parser": "^5.1.3",
         "newman": "^4.1.0",
-        "openapi2schema": "git+ssh://git@github.com/rossgrambo/openapi2schema.git"
+        "openapi2schema": "git+ssh://git@github.com/Asana/openapi2schema.git#3713fface9b8e235fc8a2102cf411c23bb223c75"
       }
     },
     "node_modules/ajv": {
@@ -1541,8 +1541,8 @@
     },
     "node_modules/openapi2schema": {
       "version": "0.5.0",
-      "resolved": "git+ssh://git@github.com/rossgrambo/openapi2schema.git#3364fa81e76d7b211fb91b067254cd42c16532b6",
-      "integrity": "sha512-AaRHKEEJNq2ZJqeouzA5DLSQI+rjM4kfYNWp/AGBFioPIfu3twTcD41ofketvAXUN5Tat7oUsvGAF3w6ah8Eag==",
+      "resolved": "git+ssh://git@github.com/Asana/openapi2schema.git#3713fface9b8e235fc8a2102cf411c23bb223c75",
+      "integrity": "sha512-By5SYGsPh7oJPn9aNNwZmvqE1XWtjch1G+eZTKMc/h4aID4CYIUQZ90JovwQnQwIYKbWQKuo7T8imPbskKWgEQ==",
       "license": "MIT",
       "dependencies": {
         "commander": "^2.11.0",
@@ -3547,8 +3547,9 @@
       }
     },
     "openapi2schema": {
-      "version": "git+ssh://git@github.com/rossgrambo/openapi2schema.git#3364fa81e76d7b211fb91b067254cd42c16532b6",
-      "from": "openapi2schema@git+ssh://git@github.com/rossgrambo/openapi2schema.git",
+      "version": "git+ssh://git@github.com/Asana/openapi2schema.git#3713fface9b8e235fc8a2102cf411c23bb223c75",
+      "integrity": "sha512-By5SYGsPh7oJPn9aNNwZmvqE1XWtjch1G+eZTKMc/h4aID4CYIUQZ90JovwQnQwIYKbWQKuo7T8imPbskKWgEQ==",
+      "from": "openapi2schema@git+ssh://git@github.com/Asana/openapi2schema.git#3713fface9b8e235fc8a2102cf411c23bb223c75",
       "requires": {
         "commander": "^2.11.0",
         "js-yaml": "^3.10.0",
diff --git a/asana2/asana/server/api/postman/package.json b/asana2/asana/server/api/postman/package.json
index 0aa48cc5f5b6..a1c1f877c748 100644
--- a/asana2/asana/server/api/postman/package.json
+++ b/asana2/asana/server/api/postman/package.json
@@ -12,6 +12,6 @@
     "commander": "^2.18.0",
     "json-schema-ref-parser": "^5.1.3",
     "newman": "^4.1.0",
-    "openapi2schema": "git+ssh://git@github.com/rossgrambo/openapi2schema.git"
+    "openapi2schema": "git+ssh://git@github.com/Asana/openapi2schema.git#3713fface9b8e235fc8a2102cf411c23bb223c75"
   }
 }
diff --git a/asana2/asana/server/openapi_spec/src/components/schemas.yaml b/asana2/asana/server/openapi_spec/src/components/schemas.yaml
index 0a39f0cde865..5b7435737a9e 100644
--- a/asana2/asana/server/openapi_spec/src/components/schemas.yaml
+++ b/asana2/asana/server/openapi_spec/src/components/schemas.yaml
@@ -2097,6 +2097,12 @@ schemas:
               HTML formatted text for the project brief.
             type: string
             example: "<body>This is a <strong>project brief</strong>.</body>"
+          text:
+            description: >-
+              [Opt In](/docs/input-output-options).
+              The plain text of the project brief.
+            type: string
+            example: "This is a project brief."
   ProjectBriefCompact:
     x-private: true
     allOf:
@@ -2111,27 +2117,17 @@ schemas:
     x-private: true
     allOf:
       - $ref: '#/components/schemas/ProjectBriefBase'
-      - type: object
-        properties:
-          text:
-            description: >-
-              The plain text of the project brief. When writing to a project
-              brief, you can specify either `html_text` (preferred) or `text`,
-              but not both.
-            type: string
-            example: "This is a project brief."
+      - x-docs-overrides:
+          properties.text.description: >-
+            The plain text of the project brief. When writing to a project
+            brief, you can specify either `html_text` (preferred) or `text`,
+            but not both.
   ProjectBriefResponse:
     x-private: true
     allOf:
       - $ref: '#/components/schemas/ProjectBriefBase'
       - type: object
         properties:
-          text:
-            description: >-
-              [Opt In](/docs/input-output-options).
-              The plain text of the project brief.
-            type: string
-            example: "This is a project brief."
           permalink_url:
             type: string
             readOnly: true
```
2. Run our build script `./gen_sand_env.sh` 
3. Notice that it give an error `Error: No resolver found for key x-docs-overrides. You can provide a resolver for this keyword in the options, or provide a default resolver.`